### PR TITLE
Issue 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,6 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-parameter-names</artifactId>
-            <version>${jackson.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/src/main/java/org/zalando/jackson/datatype/money/MoneyNode.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MoneyNode.java
@@ -2,26 +2,6 @@ package org.zalando.jackson.datatype.money;
 
 /*
  * ⁣​
- * Jackson-datatype-Money
- * ⁣⁣
- * Copyright (C) 2015 Zalando SE
- * ⁣⁣
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * ​⁣
- */
-
-/*
- * ⁣
  * jackson-datatype-money
  * ⁣⁣
  * Copyright (C) 2015 Zalando SE
@@ -29,9 +9,9 @@ package org.zalando.jackson.datatype.money;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/zalando/jackson/datatype/money/MoneyNode.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MoneyNode.java
@@ -2,7 +2,7 @@ package org.zalando.jackson.datatype.money;
 
 /*
  * ⁣​
- * jackson-datatype-money
+ * Jackson-datatype-Money
  * ⁣⁣
  * Copyright (C) 2015 Zalando SE
  * ⁣⁣
@@ -20,34 +20,55 @@ package org.zalando.jackson.datatype.money;
  * ​⁣
  */
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+/*
+ * ⁣
+ * jackson-datatype-money
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
 
-import javax.money.CurrencyUnit;
 import java.math.BigDecimal;
 
-@JsonPropertyOrder({"amount", "currency"})
+import javax.money.CurrencyUnit;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 final class MoneyNode {
 
-    @JsonProperty
     private final BigDecimal amount;
-    
-    @JsonProperty
+
     private final CurrencyUnit currency;
 
     @JsonCreator
-    MoneyNode(BigDecimal amount, CurrencyUnit currency) {
+    MoneyNode(@JsonProperty("amount") final BigDecimal amount,
+            @JsonProperty("currency") final CurrencyUnit currency) {
         this.amount = amount;
         this.currency = currency;
     }
 
+    @JsonGetter("amount")
     BigDecimal getAmount() {
         return amount;
     }
 
+    @JsonGetter("currency")
     CurrencyUnit getCurrency() {
         return currency;
     }
-    
+
 }

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializerTest.java
@@ -2,26 +2,6 @@ package org.zalando.jackson.datatype.money;
 
 /*
  * ⁣​
- * Jackson-datatype-Money
- * ⁣⁣
- * Copyright (C) 2015 Zalando SE
- * ⁣⁣
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * ​⁣
- */
-
-/*
- * ⁣
  * jackson-datatype-money
  * ⁣⁣
  * Copyright (C) 2015 Zalando SE
@@ -29,9 +9,9 @@ package org.zalando.jackson.datatype.money;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializerTest.java
@@ -2,7 +2,7 @@ package org.zalando.jackson.datatype.money;
 
 /*
  * ⁣​
- * jackson-datatype-money
+ * Jackson-datatype-Money
  * ⁣⁣
  * Copyright (C) 2015 Zalando SE
  * ⁣⁣
@@ -20,15 +20,39 @@ package org.zalando.jackson.datatype.money;
  * ​⁣
  */
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-
-import javax.money.MonetaryAmount;
-import java.io.IOException;
-import java.math.BigDecimal;
+/*
+ * ⁣
+ * jackson-datatype-money
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
 
 import static org.hamcrest.Matchers.comparesEqualTo;
+
 import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import java.math.BigDecimal;
+
+import javax.money.MonetaryAmount;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public final class MonetaryAmountDeserializerTest {
 
@@ -41,8 +65,17 @@ public final class MonetaryAmountDeserializerTest {
 
         final BigDecimal actual = amount.getNumber().numberValueExact(BigDecimal.class);
         final BigDecimal expected = new BigDecimal("29.95");
-        
+
         assertThat(actual, comparesEqualTo(expected));
     }
-    
+
+    @Test
+    public void shouldDeserializeWhenPropertiesAreInDifferentOrder() throws IOException {
+        final String content = "{\"currency\":\"EUR\",\"amount\":29.95}";
+        final MonetaryAmount amount = mapper.readValue(content, MonetaryAmount.class);
+
+        final BigDecimal actual = amount.getNumber().numberValueExact(BigDecimal.class);
+        assertThat(actual, comparesEqualTo(new BigDecimal("29.95")));
+    }
+
 }


### PR DESCRIPTION
_MoneyModule_ is not working without _ParameterNamesModule_. Additional dependencies make setup more complicated. As soon as _jackson-module-parameter-names_ dependency was declared with a scope _test_ it was not obvious that it is actually required by the library. I've added _@JsonProperty_ annotations to _MoneyNode_ class, so it can be serialized and deserialized without additional libraries.