### PR TITLE
Added Support for the org.javamoney.moneta.FastMoney implementation o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,27 @@ This module has no direct dependency on Java Money, but rather requires that cli
 
 ## Usage
 
+If you want to work with `org.javamoney.moneta.Money` as the implementation of `javax.money.MonetaryAmount` use the MoneyModul:
+
 ```java
 ObjectMapper mapper = new ObjectMapper();
 mapper.registerModule(new MoneyModule());
 ```
 
-Or alternatively you can use the SPI capabilities:
+If you want to work with `org.javamoney.moneta.FastMoney` as the implementation of `javax.money.MonetaryAmount` use the FastMoneyModul:
 
 ```java
-ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+ObjectMapper mapper = new ObjectMapper();
+mapper.registerModule(new FastMoneyModule());
+```
+
+If you are using spring boot just register a Bean
+
+```java
+@Bean
+public Module moneyModule() {
+    return new MoneyModule();
+}
 ```
 
 ## Supported Types

--- a/src/main/java/org/zalando/jackson/datatype/money/FastMoneyModule.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/FastMoneyModule.java
@@ -1,0 +1,46 @@
+package org.zalando.jackson.datatype.money;
+
+/*
+ * ⁣​
+ * jackson-datatype-money
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import javax.money.CurrencyUnit;
+import javax.money.MonetaryAmount;
+import java.util.Currency;
+
+import static com.fasterxml.jackson.core.util.VersionUtil.mavenVersionFor;
+
+public final class FastMoneyModule extends SimpleModule {
+
+    public FastMoneyModule() {
+        super(FastMoneyModule.class.getSimpleName(),
+                mavenVersionFor(FastMoneyModule.class.getClassLoader(), "org.zalando", "jackson-datatype-money"));
+        
+        addSerializer(Currency.class, new CurrencySerializer());
+        addSerializer(CurrencyUnit.class, new CurrencyUnitSerializer());
+        addSerializer(MonetaryAmount.class, new MonetaryAmountFastMoneySerializer());
+        
+        addDeserializer(Currency.class, new CurrencyDeserializer());
+        addDeserializer(CurrencyUnit.class, new CurrencyUnitDeserializer());
+        addDeserializer(MonetaryAmount.class, new MonetaryAmountFastMoneyDeserializer());
+    }
+
+}

--- a/src/main/java/org/zalando/jackson/datatype/money/FastMoneyNode.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/FastMoneyNode.java
@@ -20,20 +20,33 @@ package org.zalando.jackson.datatype.money;
  * ​⁣
  */
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import org.javamoney.moneta.FastMoney;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.money.MonetaryAmount;
-import java.io.IOException;
+import javax.money.CurrencyUnit;
 
-public final class MonetaryAmountFastMoneyDeserializer extends JsonDeserializer<MonetaryAmount> {
+final class FastMoneyNode {
 
-    @Override
-    public MonetaryAmount deserialize(JsonParser parser, DeserializationContext context) throws IOException {
-        final FastMoneyNode node = parser.readValueAs(FastMoneyNode.class);
-        return FastMoney.of(node.getAmount(), node.getCurrency());
+    private final Double amount;
+
+    private final CurrencyUnit currency;
+
+    @JsonCreator
+    FastMoneyNode(@JsonProperty("amount") final Double amount,
+                  @JsonProperty("currency") final CurrencyUnit currency) {
+        this.amount = amount;
+        this.currency = currency;
+    }
+
+    @JsonGetter("amount")
+    Double getAmount() {
+        return amount;
+    }
+
+    @JsonGetter("currency")
+    CurrencyUnit getCurrency() {
+        return currency;
     }
 
 }

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFastMoneyDeserializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFastMoneyDeserializer.java
@@ -1,0 +1,39 @@
+package org.zalando.jackson.datatype.money;
+
+/*
+ * ⁣​
+ * jackson-datatype-money
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.javamoney.moneta.FastMoney;
+
+import javax.money.MonetaryAmount;
+import java.io.IOException;
+
+public final class MonetaryAmountFastMoneyDeserializer extends JsonDeserializer<MonetaryAmount> {
+
+    @Override
+    public MonetaryAmount deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        final MoneyNode node = parser.readValueAs(MoneyNode.class);
+        return FastMoney.of(node.getAmount(), node.getCurrency());
+    }
+
+}

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFastMoneySerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFastMoneySerializer.java
@@ -1,0 +1,44 @@
+package org.zalando.jackson.datatype.money;
+
+/*
+ * ⁣​
+ * jackson-datatype-money
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import javax.money.CurrencyUnit;
+import javax.money.MonetaryAmount;
+import java.io.IOException;
+import java.math.BigDecimal;
+
+public final class MonetaryAmountFastMoneySerializer extends JsonSerializer<MonetaryAmount> {
+
+    @Override
+    public void serialize(MonetaryAmount value, JsonGenerator generator, SerializerProvider provider)
+            throws IOException {
+
+        final BigDecimal amount = value.getNumber().numberValueExact(BigDecimal.class);
+        final CurrencyUnit currency = value.getCurrency();
+
+        generator.writeObject(new MoneyNode(amount, currency));
+    }
+
+}

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFastMoneySerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFastMoneySerializer.java
@@ -35,10 +35,10 @@ public final class MonetaryAmountFastMoneySerializer extends JsonSerializer<Mone
     public void serialize(MonetaryAmount value, JsonGenerator generator, SerializerProvider provider)
             throws IOException {
 
-        final BigDecimal amount = value.getNumber().numberValueExact(BigDecimal.class);
+        final Double amount = value.getNumber().numberValueExact(Double.class);
         final CurrencyUnit currency = value.getCurrency();
 
-        generator.writeObject(new MoneyNode(amount, currency));
+        generator.writeObject(new FastMoneyNode(amount, currency));
     }
 
 }

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountFastMoneyDeserializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountFastMoneyDeserializerTest.java
@@ -20,25 +20,21 @@ package org.zalando.jackson.datatype.money;
  * ​⁣
  */
 
-import static org.hamcrest.Matchers.comparesEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
-
-import java.io.IOException;
-
-import java.math.BigDecimal;
-
-import javax.money.MonetaryAmount;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.javamoney.moneta.FastMoney;
 import org.javamoney.moneta.Money;
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.money.MonetaryAmount;
+import java.io.IOException;
+import java.math.BigDecimal;
 
-public final class MonetaryAmountDeserializerTest {
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
 
-    private final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+public final class MonetaryAmountFastMoneyDeserializerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new FastMoneyModule());
 
     @Test
     public void shouldDeserialize() throws IOException {
@@ -49,7 +45,13 @@ public final class MonetaryAmountDeserializerTest {
         final BigDecimal expected = new BigDecimal("29.95");
 
         assertThat(actual, comparesEqualTo(expected));
-        assertThat(amount, is(instanceOf(Money.of(0.0,"CHF").getClass())));
+        assertThat(amount, is(instanceOf(FastMoney.of(0.0, "CHF").getClass())));
+    }
+
+    @Test (expected = ArithmeticException.class)
+    public void shouldNotDeserialize() throws IOException {
+        final String content = "{\"amount\":29.955555,\"currency\":\"EUR\"}";
+         mapper.readValue(content, MonetaryAmount.class);
     }
 
     @Test
@@ -59,7 +61,7 @@ public final class MonetaryAmountDeserializerTest {
 
         final BigDecimal actual = amount.getNumber().numberValueExact(BigDecimal.class);
         assertThat(actual, comparesEqualTo(new BigDecimal("29.95")));
-        assertThat(amount, is(instanceOf(Money.of(0.0,"CHF").getClass())));
+        assertThat(amount, is(instanceOf(FastMoney.of(0.0,"CHF").getClass())));
     }
 
 }

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountFastMoneySerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountFastMoneySerializerTest.java
@@ -1,0 +1,44 @@
+package org.zalando.jackson.datatype.money;
+
+/*
+ * ⁣​
+ * jackson-datatype-money
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.javamoney.moneta.Money;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class MonetaryAmountFastMoneySerializerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new FastMoneyModule());
+
+    @Test
+    public void shouldSerialize() throws JsonProcessingException {
+        final String expected = "{\"amount\":29.95,\"currency\":\"EUR\"}";
+        final String actual = mapper.writeValueAsString(Money.of(29.95, "EUR"));
+
+        assertThat(actual, is(expected));
+    }
+    
+    
+}


### PR DESCRIPTION
…f javax.money.MonetaryAmount. To use it the FastMoneyModule has to be used. Remark: The Serializer is the same for Money and FastMoney. But for symetrical reasons I made a copy from the MonetaryAmountSerializer to MonetaryAmountFastMoneySerializer