### PR TITLE
Allow users to register custom formatters to format the MonetaryAmount.

### DIFF
--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
@@ -26,10 +26,19 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import javax.money.CurrencyUnit;
 import javax.money.MonetaryAmount;
+import javax.money.format.MonetaryAmountFormat;
+import javax.money.format.MonetaryFormats;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Locale;
 
 public final class MonetaryAmountSerializer extends JsonSerializer<MonetaryAmount> {
+
+    private MonetaryAmountFormat format;
+
+    public MonetaryAmountSerializer(MonetaryAmountFormat format) {
+        this.format = format;
+    }
 
     @Override
     public void serialize(final MonetaryAmount value, final JsonGenerator generator, final SerializerProvider provider)
@@ -37,8 +46,9 @@ public final class MonetaryAmountSerializer extends JsonSerializer<MonetaryAmoun
 
         final BigDecimal amount = value.getNumber().numberValueExact(BigDecimal.class);
         final CurrencyUnit currency = value.getCurrency();
+        final String formattedValue = format.format( value );
 
-        generator.writeObject(new MoneyNode(amount, currency));
+        generator.writeObject(new MoneyNode(amount, currency, formattedValue));
     }
 
 }

--- a/src/main/java/org/zalando/jackson/datatype/money/MoneyModule.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MoneyModule.java
@@ -24,24 +24,35 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import javax.money.CurrencyUnit;
 import javax.money.MonetaryAmount;
+import javax.money.format.MonetaryAmountFormat;
+import javax.money.format.MonetaryFormats;
 import java.util.Currency;
+import java.util.Locale;
 
 import static com.fasterxml.jackson.core.util.VersionUtil.mavenVersionFor;
 
 public final class MoneyModule extends SimpleModule {
 
     public MoneyModule() {
-        this(new MoneyFactory());
+        this(new MoneyFactory(), MonetaryFormats.getAmountFormat( Locale.getDefault() ));
+    }
+
+    public MoneyModule(MonetaryAmountFormat format) {
+        this(new MoneyFactory(), format);
     }
 
     public MoneyModule(final MonetaryAmountFactory factory) {
+        this(factory, MonetaryFormats.getAmountFormat( Locale.getDefault() ));
+    }
+
+    public MoneyModule(final MonetaryAmountFactory factory, final MonetaryAmountFormat format) {
         super(MoneyModule.class.getSimpleName(),
                 mavenVersionFor(MoneyModule.class.getClassLoader(), "org.zalando", "jackson-datatype-money"));
-        
+
         addSerializer(Currency.class, new CurrencySerializer());
         addSerializer(CurrencyUnit.class, new CurrencyUnitSerializer());
-        addSerializer(MonetaryAmount.class, new MonetaryAmountSerializer());
-        
+        addSerializer(MonetaryAmount.class, new MonetaryAmountSerializer(format));
+
         addDeserializer(Currency.class, new CurrencyDeserializer());
         addDeserializer(CurrencyUnit.class, new CurrencyUnitDeserializer());
         addDeserializer(MonetaryAmount.class, new MonetaryAmountDeserializer(factory));

--- a/src/main/java/org/zalando/jackson/datatype/money/MoneyNode.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MoneyNode.java
@@ -33,11 +33,15 @@ final class MoneyNode {
 
     private final CurrencyUnit currency;
 
+    private final String formattedValue;
+
     @JsonCreator
     MoneyNode(@JsonProperty("amount") final BigDecimal amount,
-            @JsonProperty("currency") final CurrencyUnit currency) {
+            @JsonProperty("currency") final CurrencyUnit currency,
+              @JsonProperty("formattedValue") final String formattedValue) {
         this.amount = amount;
         this.currency = currency;
+        this.formattedValue = formattedValue;
     }
 
     @JsonGetter("amount")
@@ -50,4 +54,6 @@ final class MoneyNode {
         return currency;
     }
 
+    @JsonGetter("formattedValue")
+    String getFormattedValue() { return formattedValue; }
 }

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
@@ -23,21 +23,38 @@ package org.zalando.jackson.datatype.money;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.javamoney.moneta.Money;
+import org.javamoney.moneta.format.CurrencyStyle;
 import org.junit.Test;
+
+import javax.money.format.AmountFormatQueryBuilder;
+import javax.money.format.MonetaryFormats;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public final class MonetaryAmountSerializerTest {
 
-    private final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
-
     @Test
-    public void shouldSerialize() throws JsonProcessingException {
-        final String expected = "{\"amount\":29.95,\"currency\":\"EUR\"}";
+    public void shouldSerializeNoFormatter() throws JsonProcessingException {
+        final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        final String expected = "{\"amount\":29.95,\"currency\":\"EUR\",\"formattedValue\":\"EUR29.95\"}";
         final String actual = mapper.writeValueAsString(Money.of(29.95, "EUR"));
 
         assertThat(actual, is(expected));
     }
+
+    @Test
+    public void shouldSerializeWithFormatter() throws JsonProcessingException {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule( new MoneyModule( MonetaryFormats.getAmountFormat(
+            AmountFormatQueryBuilder.of( Locale.US ).set( CurrencyStyle.SYMBOL ).build()
+        )) );
+        final String expected = "{\"amount\":29.95,\"currency\":\"USD\",\"formattedValue\":\"$29.95\"}";
+        final String actual = mapper.writeValueAsString(Money.of(29.95, "USD"));
+
+        assertThat(actual, is(expected));
+    }
+
 
 }


### PR DESCRIPTION
Hello,

I'd like the serialized JSON to include also `formattedValue`. Please review this pull request - it allows users to specify a `MonetaryAmountFormat` when creating `MoneyModule`, to format the monetary amount accordingly. This way instead of returning:
````json
      "price" : {
        "amount" : 34,
        "currency" : "USD"
      },
````
we can now return:
````json
      "price" : {
        "amount" : 34,
        "currency" : "USD",
        "formattedValue" : "$34.00"
      },
````