### PR TITLE
Refactor maven profiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@ language: java
 
 sudo: false
 
-script:
-  - jdk_switcher use oraclejdk7
-  - mvn clean verify -P jdk7
-  - jdk_switcher use oraclejdk8
-  - mvn clean verify -P jdk8
+jdk:
+  - oraclejdk8
+  - oraclejdk7
 
-after_success:
-  - mvn clean test jacoco:report coveralls:report
+script:
+  - mvn clean verify jacoco:report coveralls:report
 
 notifications:
   email:

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,9 @@
         </profile>
         <profile>
             <id>jdk7</id>
+            <activation>
+                <jdk>1.7</jdk>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>javax.money</groupId>
@@ -298,7 +301,7 @@
         <profile>
             <id>jdk8</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <jdk>[1.8,)</jdk>
             </activation>
             <dependencies>
                 <dependency>

--- a/release.sh
+++ b/release.sh
@@ -4,10 +4,9 @@ set -e
 
 mvn scm:check-local-modification
 
-# test using current jdk
-# for realistic tests the jdk has to be switched in addition to the profile
-# to avoid dependencies on rt.jar
-mvn clean test
+# test
+mvn dependency:tree clean test -Pjdk7,-jdk8
+mvn dependency:tree clean test -Pjdk8,-jdk7
 
 # release
 mvn versions:set

--- a/release.sh
+++ b/release.sh
@@ -4,15 +4,16 @@ set -e
 
 mvn scm:check-local-modification
 
-# test
-mvn clean test -P jdk7
-mvn clean test -P jdk8
+# test using current jdk
+# for realistic tests the jdk has to be switched in addition to the profile
+# to avoid dependencies on rt.jar
+mvn clean test
 
 # release
 mvn versions:set
 git add pom.xml
 git commit
-mvn clean deploy -P release,jdk8
+mvn clean deploy -P release
 mvn scm:tag
 
 # next development version


### PR DESCRIPTION
It looks like the profile is activated even in a dependency, in that case activation should be based on the currently used jdk version.

This is an alternative to PR #22 and should fix issue #20 