### PR TITLE
Use deserializationContext.readValue instead of parser.readValueAs in MonetaryAmountDeserializer

### DIFF
--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializer.java
@@ -45,7 +45,7 @@ public final class MonetaryAmountDeserializer extends JsonDeserializer<MonetaryA
 
     @Override
     public MonetaryAmount deserialize(final JsonParser parser, final DeserializationContext context) throws IOException {
-        final MoneyNode node = parser.readValueAs(MoneyNode.class);
+        final MoneyNode node = context.readValue(parser, MoneyNode.class);
         return factory.create(node.getAmount(), node.getCurrency());
     }
 

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializerTest.java
@@ -155,19 +155,6 @@ public final class MonetaryAmountDeserializerTest {
         // we need a json node to get a TreeTraversingParser with codec of type ObjectReader
         JsonNode ownerNode = unit.readTree("{ \"value\" : {\"amount\":29.95,\"currency\":\"EUR\",\"formatted\":\"30.00 EUR\"} }");
         
-        class Owner {
-            
-            private MonetaryAmount value;
-
-            public MonetaryAmount getValue() {
-                return value;
-            }
-
-            public void setValue(MonetaryAmount value) {
-                this.value = value;
-            }
-        }
-
         
         final Owner owner = new Owner();
         owner.setValue(amount);
@@ -178,5 +165,17 @@ public final class MonetaryAmountDeserializerTest {
         assertThat(result.getValue(), is(amount));
     }
     
+    private static class Owner {
+        
+        private MonetaryAmount value;
+
+        public MonetaryAmount getValue() {
+            return value;
+        }
+
+        public void setValue(MonetaryAmount value) {
+            this.value = value;
+        }
+    }
 
 }


### PR DESCRIPTION
The deserializer should avoid using JsonParser.readValueAs, as the
underlying codec might wrongly bind the result to a "valueToUpdate",
which will then result in an error. Using DeserializationContext just
"plainly" deserializes the value and returns it. No updating of
contained beans.

Maybe a bit of background first: I'm using Spring Data Rest to create (POST) and update (PUT) resources. A resource, let's call it owner.json might look like this:

`{ "value" : { "amount" : 42, "currency" : "EUR"}}` 

The value part of course is a `MonetaryAmount`. POSTing works fine, but PUTting resulted in an error as Jackson wants to set `amount` on the root object, and not on `value`. I did some digging and found out that `parser.readValueAs` uses its underlying `codec` to deserialize values. This can, in the current version 2.6 either be an `ObjectMapper` or and `ObjectReader`.  The problem arises when using the latter. Jackson's `TreeTraversingParser` uses an `ObjectReader` as `codec`, which in turn contains a `valueToUpdate`, that will be updated (i.e. properties will be set) on calling `readValueAs`. This is of course something we want to avoid inside a `Deserializer`. Its job solely should be to read the next value of the parser and create an Object from it. Setting values should be done outside of the deserializer.
Using `DeserializationContext.readValue` does exactly that. It finds the correct deserializer for the types, reads the value (without using the parser's underlying coded) and returns the `MoneyNode`.

Please see the added unit test on how to reproduce the faulty behavior.

tl;dr: use `DeserializationContext.readValue` instead of `JsonParser.readValueAs` for no-strings-attached deserialization.