### PR TITLE
Add support for string amounts

### DIFF
--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializer.java
@@ -48,7 +48,7 @@ public final class MonetaryAmountDeserializer<M extends MonetaryAmount> extends 
             parser.nextToken();
 
             if (field.equals(names.getAmount())) {
-                amount = parser.getDecimalValue();
+                amount = context.readValue(parser, BigDecimal.class);
             } else if (field.equals(names.getCurrency())) {
                 currency = context.readValue(parser, CurrencyUnit.class);
             } else if (field.equals(names.getFormatted())) {

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializerTest.java
@@ -113,6 +113,17 @@ public final class MonetaryAmountDeserializerTest<M extends MonetaryAmount> {
     }
 
     @Test
+    public void shouldDeserializeCorrectlyWhenAmountIsAStringValue() throws IOException {
+        final ObjectMapper unit = unit();
+
+        final String content = "{\"currency\":\"EUR\",\"amount\":\"29.95\"}";
+        final MonetaryAmount amount = unit.readValue(content, type);
+
+        assertThat(amount.getNumber().numberValueExact(BigDecimal.class), comparesEqualTo(new BigDecimal("29.95")));
+        assertThat(amount.getCurrency().getCurrencyCode(), is("EUR"));
+    }
+
+    @Test
     public void shouldDeserializeCorrectlyWhenPropertiesAreInDifferentOrder() throws IOException {
         final ObjectMapper unit = unit();
 


### PR DESCRIPTION
I'm consuming an API that serializes the amounts as string values and the current implementation fails at deserialization with a JsonMappingException (Current token (VALUE_STRING) not numeric, can not use numeric value accessors)

I thought it doesn't hurt to support this use case in the library and so here is my PR :)

The way via the context should not add much overhead performance wise as the BigIntegerDeserializer does more or less the same in the INT and FLOAT cases but also handles Strings correctly. The indirection _just_ adds some more stack frames.