### PR TITLE
Enrich MonetaryAmount and CurrencyUnit serializer with json schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
             <version>2.8.47</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jsonSchema</artifactId>
+            <scope>test</scope>
+            <version>${jackson.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/zalando/jackson/datatype/money/AmountWriter.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/AmountWriter.java
@@ -2,8 +2,10 @@ package org.zalando.jackson.datatype.money;
 
 import javax.money.MonetaryAmount;
 
-interface AmountWriter {
+interface AmountWriter<T> {
 
-    Object write(final MonetaryAmount amount);
+    Class<T> getType();
+
+    T write(final MonetaryAmount amount);
 
 }

--- a/src/main/java/org/zalando/jackson/datatype/money/CurrencyUnitSerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/CurrencyUnitSerializer.java
@@ -1,13 +1,20 @@
 package org.zalando.jackson.datatype.money;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import javax.money.CurrencyUnit;
 import java.io.IOException;
 
-public final class CurrencyUnitSerializer extends JsonSerializer<CurrencyUnit> {
+public final class CurrencyUnitSerializer extends StdSerializer<CurrencyUnit> {
+
+    CurrencyUnitSerializer() {
+        super(CurrencyUnit.class);
+    }
 
     @Override
     public void serialize(final CurrencyUnit value, final JsonGenerator generator, final SerializerProvider serializers)
@@ -15,4 +22,8 @@ public final class CurrencyUnitSerializer extends JsonSerializer<CurrencyUnit> {
         generator.writeString(value.getCurrencyCode());
     }
 
+    @Override
+    public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint) throws JsonMappingException {
+        visitor.expectStringFormat(typeHint);
+    }
 }

--- a/src/main/java/org/zalando/jackson/datatype/money/DecimalAmountWriter.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/DecimalAmountWriter.java
@@ -4,7 +4,12 @@ import javax.money.MonetaryAmount;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
-final class DecimalAmountWriter implements AmountWriter {
+final class DecimalAmountWriter implements AmountWriter<BigDecimal> {
+
+    @Override
+    public Class<BigDecimal> getType() {
+        return BigDecimal.class;
+    }
 
     @Override
     public BigDecimal write(final MonetaryAmount amount) {

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
@@ -1,9 +1,14 @@
 package org.zalando.jackson.datatype.money;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import javax.annotation.Nullable;
 import javax.money.CurrencyUnit;
@@ -12,7 +17,7 @@ import javax.money.format.MonetaryAmountFormat;
 import java.io.IOException;
 import java.util.Locale;
 
-final class MonetaryAmountSerializer extends JsonSerializer<MonetaryAmount> {
+final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
 
     private final FieldNames names;
     private final AmountWriter writer;
@@ -20,9 +25,27 @@ final class MonetaryAmountSerializer extends JsonSerializer<MonetaryAmount> {
 
     MonetaryAmountSerializer(final FieldNames names, final AmountWriter writer,
             final MonetaryAmountFormatFactory factory) {
+        super(MonetaryAmount.class);
         this.writer = writer;
         this.factory = factory;
         this.names = names;
+    }
+
+    @Override
+    public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint) throws JsonMappingException {
+        JsonObjectFormatVisitor jsonObjectFormatVisitor = visitor.expectObjectFormat(typeHint);
+
+        JavaType amountType = visitor.getProvider().constructType(writer.getType());
+        JsonSerializer<Object> amountSerializer = visitor.getProvider().findValueSerializer(writer.getType());
+        jsonObjectFormatVisitor.property(names.getAmount(), amountSerializer, amountType);
+
+        JavaType currencyUnitType = visitor.getProvider().constructType(CurrencyUnit.class);
+        JsonSerializer<Object> currencyUnitSerializer = visitor.getProvider().findValueSerializer(CurrencyUnit.class);
+        jsonObjectFormatVisitor.property(names.getCurrency(), currencyUnitSerializer, currencyUnitType);
+
+        JavaType stringType = visitor.getProvider().constructType(String.class);
+        JsonSerializer<Object> stringSerializer = visitor.getProvider().findValueSerializer(String.class);
+        jsonObjectFormatVisitor.optionalProperty(names.getFormatted(), stringSerializer, stringType);
     }
 
     @Override

--- a/src/main/java/org/zalando/jackson/datatype/money/QuotedDecimalAmountWriter.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/QuotedDecimalAmountWriter.java
@@ -2,9 +2,14 @@ package org.zalando.jackson.datatype.money;
 
 import javax.money.MonetaryAmount;
 
-final class QuotedDecimalAmountWriter implements AmountWriter {
+final class QuotedDecimalAmountWriter implements AmountWriter<String> {
 
     private final DecimalAmountWriter delegate = new DecimalAmountWriter();
+
+    @Override
+    public Class<String> getType() {
+        return String.class;
+    }
 
     @Override
     public String write(final MonetaryAmount amount) {

--- a/src/test/java/org/zalando/jackson/datatype/money/CurrencyUnitSchemaSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/CurrencyUnitSchemaSerializerTest.java
@@ -1,0 +1,26 @@
+package org.zalando.jackson.datatype.money;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
+import org.junit.Test;
+
+import javax.money.CurrencyUnit;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class CurrencyUnitSchemaSerializerTest {
+
+    private final ObjectMapper unit = new ObjectMapper().findAndRegisterModules();
+
+    @Test
+    public void shouldSerializeJsonSchema() throws Exception {
+        JsonSchemaGenerator generator = new JsonSchemaGenerator(unit);
+        JsonSchema jsonSchema = generator.generateSchema(CurrencyUnit.class);
+        final String actual = unit.writeValueAsString(jsonSchema);
+        final String expected = "{\"type\":\"string\"}";
+
+        assertThat(actual, is(expected));
+    }
+}

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSchemaSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSchemaSerializerTest.java
@@ -1,0 +1,67 @@
+package org.zalando.jackson.datatype.money;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
+import org.junit.Test;
+
+import javax.money.MonetaryAmount;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class MonetaryAmountSchemaSerializerTest {
+
+    @Test
+    public void shouldSerializeJsonSchema() throws Exception {
+        ObjectMapper unit = unit(module());
+        JsonSchemaGenerator generator = new JsonSchemaGenerator(unit);
+        JsonSchema jsonSchema = generator.generateSchema(MonetaryAmount.class);
+        final String actual = unit.writeValueAsString(jsonSchema);
+        final String expected = "{\"type\":\"object\",\"id\":\"urn:jsonschema:javax:money:MonetaryAmount\",\"properties\":" +
+                "{\"amount\":{\"type\":\"number\",\"required\":true}," +
+                "\"currency\":{\"type\":\"string\",\"required\":true}," +
+                "\"formatted\":{\"type\":\"string\"}}}";
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void shouldSerializeJsonSchemaWithCustomFieldNames() throws Exception {
+        ObjectMapper unit = unit(module().withAmountFieldName("value")
+                                         .withCurrencyFieldName("unit")
+                                         .withFormattedFieldName("pretty"));
+        JsonSchemaGenerator generator = new JsonSchemaGenerator(unit);
+        JsonSchema jsonSchema = generator.generateSchema(MonetaryAmount.class);
+        final String actual = unit.writeValueAsString(jsonSchema);
+        final String expected = "{\"type\":\"object\",\"id\":\"urn:jsonschema:javax:money:MonetaryAmount\",\"properties\":" +
+                "{\"value\":{\"type\":\"number\",\"required\":true}," +
+                "\"unit\":{\"type\":\"string\",\"required\":true}," +
+                "\"pretty\":{\"type\":\"string\"}}}";
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void shouldSerializeJsonSchemaWithQuotedDecimalNumbers() throws Exception {
+        ObjectMapper unit = unit(module().withQuotedDecimalNumbers());
+        JsonSchemaGenerator generator = new JsonSchemaGenerator(unit);
+        JsonSchema jsonSchema = generator.generateSchema(MonetaryAmount.class);
+        final String actual = unit.writeValueAsString(jsonSchema);
+        final String expected = "{\"type\":\"object\",\"id\":\"urn:jsonschema:javax:money:MonetaryAmount\",\"properties\":" +
+                "{\"amount\":{\"type\":\"string\",\"required\":true}," +
+                "\"currency\":{\"type\":\"string\",\"required\":true}," +
+                "\"formatted\":{\"type\":\"string\"}}}";
+
+        assertThat(actual, is(expected));
+    }
+
+    private ObjectMapper unit(final Module module) {
+        return new ObjectMapper().registerModule(module);
+    }
+
+    private MoneyModule module() {
+        return new MoneyModule();
+    }
+}


### PR DESCRIPTION
Hello, 
Here is a PR to generate a proper `JsonSchema` for `MonetaryAmount` and `CurrencyUnit`.
Using Jackson JsonSchemaGenerator 
```java
JsonSchemaGenerator generator = new JsonSchemaGenerator(objectMapper);
JsonSchema jsonSchema = generator.generateSchema(MonetaryAmount.class);
```
currently gives the following output
```javascript
{"type":"any"}
```
and will now output
```javascript
{
   "type":"object",
   "id":"urn:jsonschema:javax:money:MonetaryAmount",
   "properties":{
      "amount":{
         "type":"number",
         "required":true
      },
      "currency":{
         "type":"string",
         "required":true
      },
      "formatted":{
         "type":"string"
      }
   }
}
```
and simply `{"type":"string"}` instead of `{"type":"any"}` for `CurrencyUnit`