### PR TITLE
Renamed locale parameter

### DIFF
--- a/src/main/java/org/zalando/jackson/datatype/money/DefaultMonetaryAmountFormatFactory.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/DefaultMonetaryAmountFormatFactory.java
@@ -10,8 +10,8 @@ import java.util.Locale;
 final class DefaultMonetaryAmountFormatFactory implements MonetaryAmountFormatFactory {
 
     @Override
-    public MonetaryAmountFormat create(final Locale locale) {
-        return MonetaryFormats.getAmountFormat(locale);
+    public MonetaryAmountFormat create(final Locale defaultLocale) {
+        return MonetaryFormats.getAmountFormat(defaultLocale);
     }
     
 }

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFormatFactory.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFormatFactory.java
@@ -7,6 +7,6 @@ import java.util.Locale;
 public interface MonetaryAmountFormatFactory {
 
     @Nullable
-    MonetaryAmountFormat create(final Locale locale);
+    MonetaryAmountFormat create(final Locale defaultLocale);
 
 }

--- a/src/main/java/org/zalando/jackson/datatype/money/NoopMonetaryAmountFormatFactory.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/NoopMonetaryAmountFormatFactory.java
@@ -6,7 +6,7 @@ import java.util.Locale;
 final class NoopMonetaryAmountFormatFactory implements MonetaryAmountFormatFactory {
 
     @Override
-    public MonetaryAmountFormat create(final Locale locale) {
+    public MonetaryAmountFormat create(final Locale defaultLocale) {
         return null;
     }
     


### PR DESCRIPTION
Fixes #71 

It's an alternative to #72 that does not introduce a new API, but rather embrace the existing one. The original requirement from #71 should be implemented as follows:

```java
final class LocaleAwareMonetaryAmountFormatFactory implements MonetaryAmountFormatFactory {

    private final Supplier<Locale> currentLocale;

    LocaleAwareMonetaryAmountFormatFactory(Supplier<Locale> currentLocale) {
        this.currentLocale = currentLocale;
    }

    @Override
    public MonetaryAmountFormat create(final Locale defaultLocale) {
        @Nullable Locale locale = currentLocale.get();
        return MonetaryFormats.getAmountFormat(locale == null ? defaultLocale : locale);
    }
    
}
```

@ptahchiev