### PR TITLE
Bumped finder plugin version and fixed module-info issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,8 @@
             <plugin>
                 <groupId>org.basepom.maven</groupId>
                 <artifactId>duplicate-finder-maven-plugin</artifactId>
-                <version>1.3.0</version>
+                <!-- 1.3.0 requires java 8 or higher -->
+                <version>1.2.1</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
             <plugin>
                 <groupId>org.basepom.maven</groupId>
                 <artifactId>duplicate-finder-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.3.0</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -165,9 +165,6 @@
                         <configuration>
                             <failBuildInCaseOfDifferentContentConflict>true</failBuildInCaseOfDifferentContentConflict>
                             <failBuildInCaseOfEqualContentConflict>false</failBuildInCaseOfEqualContentConflict>
-                            <ignoredClassPatterns>
-                                <ignoredClassPattern>module-info</ignoredClassPattern>
-                            </ignoredClassPatterns>
                             <ignoredResourcePatterns>
                                 <ignoredResourcePattern>.*</ignoredResourcePattern>
                             </ignoredResourcePatterns>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bumped finder plugin (not sure why dependabot didn't do it...).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1.3.0 excludes module-info by default, which means we no longer need to configure it manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
