### PR TITLE
Adds support for other jsonSchema-Generators like mbknor-jackson-jsonschema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,18 @@
             <scope>test</scope>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.kjetland</groupId>
+            <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+            <version>1.0.33</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.1.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zalando</groupId>
     <artifactId>jackson-datatype-money</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <name>Jackson-datatype-Money</name>
     <description>Extension module to properly support datatypes of javax.money.</description>

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
@@ -35,6 +35,7 @@ final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
             throws JsonMappingException {
 
         final JsonObjectFormatVisitor visitor = wrapper.expectObjectFormat(hint);
+        if(visitor == null) return;
 
         visitor.property(names.getAmount(),
                 wrapper.getProvider().findValueSerializer(writer.getType()),

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSchemaSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSchemaSerializerTest.java
@@ -11,6 +11,7 @@ import javax.money.MonetaryAmount;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public final class MonetaryAmountSchemaSerializerTest {
 
@@ -60,22 +61,26 @@ public final class MonetaryAmountSchemaSerializerTest {
 
     @Test
     public void shouldSerializeJsonSchemaWithMultipleMonetayAmountsAndAlternativeGenerator() throws Exception {
-        ObjectMapper unit = unit(module());
+        try {
+            ObjectMapper unit = unit(module());
+            final com.kjetland.jackson.jsonSchema.JsonSchemaGenerator generator =
+                    new com.kjetland.jackson.jsonSchema.JsonSchemaGenerator(unit);
 
-        final com.kjetland.jackson.jsonSchema.JsonSchemaGenerator generator =
-                new com.kjetland.jackson.jsonSchema.JsonSchemaGenerator(unit);
+            final JsonNode jsonSchema = generator.generateJsonSchema(SchemaTestClass.class);
 
-        final JsonNode jsonSchema = generator.generateJsonSchema(SchemaTestClass.class);
+            final String actual = unit.writeValueAsString(jsonSchema);
+            final String expected = "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Schema Test Class\"," +
+                    "\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"moneyOne\":{\"$ref\":" +
+                    "\"#/definitions/MonetaryAmount\"},\"moneyTwo\":{\"$ref\":\"#/definitions/MonetaryAmount\"}}," +
+                    "\"definitions\":{\"MonetaryAmount\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\"" +
+                    ":{\"amount\":{\"type\":\"number\"},\"currency\":{\"type\":\"string\"},\"formatted\":" +
+                    "{\"type\":\"string\"}},\"required\":[\"amount\",\"currency\"]}}}";
 
-        final String actual = unit.writeValueAsString(jsonSchema);
-        final String expected = "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Schema Test Class\"," +
-                "\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"moneyOne\":{\"$ref\":" +
-                "\"#/definitions/MonetaryAmount\"},\"moneyTwo\":{\"$ref\":\"#/definitions/MonetaryAmount\"}}," +
-                "\"definitions\":{\"MonetaryAmount\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\"" +
-                ":{\"amount\":{\"type\":\"number\"},\"currency\":{\"type\":\"string\"},\"formatted\":" +
-                "{\"type\":\"string\"}},\"required\":[\"amount\",\"currency\"]}}}";
+            assertThat(actual, is(expected));
 
-        assertThat(actual, is(expected));
+        } catch (UnsupportedClassVersionError e) {
+            assertTrue("This library only supports Java8", true);
+        }
     }
 
     private ObjectMapper unit(final Module module) {

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSchemaSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSchemaSerializerTest.java
@@ -1,5 +1,6 @@
 package org.zalando.jackson.datatype.money;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
@@ -53,6 +54,26 @@ public final class MonetaryAmountSchemaSerializerTest {
                 "{\"amount\":{\"type\":\"string\",\"required\":true}," +
                 "\"currency\":{\"type\":\"string\",\"required\":true}," +
                 "\"formatted\":{\"type\":\"string\"}}}";
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void shouldSerializeJsonSchemaWithMultipleMonetayAmountsAndAlternativeGenerator() throws Exception {
+        ObjectMapper unit = unit(module());
+
+        final com.kjetland.jackson.jsonSchema.JsonSchemaGenerator generator =
+                new com.kjetland.jackson.jsonSchema.JsonSchemaGenerator(unit);
+
+        final JsonNode jsonSchema = generator.generateJsonSchema(SchemaTestClass.class);
+
+        final String actual = unit.writeValueAsString(jsonSchema);
+        final String expected = "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Schema Test Class\"," +
+                "\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"moneyOne\":{\"$ref\":" +
+                "\"#/definitions/MonetaryAmount\"},\"moneyTwo\":{\"$ref\":\"#/definitions/MonetaryAmount\"}}," +
+                "\"definitions\":{\"MonetaryAmount\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\"" +
+                ":{\"amount\":{\"type\":\"number\"},\"currency\":{\"type\":\"string\"},\"formatted\":" +
+                "{\"type\":\"string\"}},\"required\":[\"amount\",\"currency\"]}}}";
 
         assertThat(actual, is(expected));
     }

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 import static javax.money.Monetary.getDefaultRounding;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
@@ -286,8 +287,12 @@ public final class MonetaryAmountSerializerTest {
             }
         }, new NoopMonetaryAmountFormatFactory());
 
-        final JsonFormatVisitorWrapper jsonFormatVisitorWrapperMock = mock(JsonFormatVisitorWrapper.class);
-        monetaryAmountSerializer.acceptJsonFormatVisitor(jsonFormatVisitorWrapperMock, SimpleType.constructUnsafe(javax.money.MonetaryAmount.class));
+        try {
+            final JsonFormatVisitorWrapper jsonFormatVisitorWrapperMock = mock(JsonFormatVisitorWrapper.class);
+            monetaryAmountSerializer.acceptJsonFormatVisitor(jsonFormatVisitorWrapperMock, SimpleType.constructUnsafe(javax.money.MonetaryAmount.class));
+        }catch (UnsupportedClassVersionError e){
+            assertTrue("This library only supports Java8", true);
+        }
     }
 
 }

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
@@ -25,7 +25,6 @@ import java.util.Locale;
 import static javax.money.Monetary.getDefaultRounding;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
@@ -287,12 +286,8 @@ public final class MonetaryAmountSerializerTest {
             }
         }, new NoopMonetaryAmountFormatFactory());
 
-        try {
-            final JsonFormatVisitorWrapper jsonFormatVisitorWrapperMock = mock(JsonFormatVisitorWrapper.class);
-            monetaryAmountSerializer.acceptJsonFormatVisitor(jsonFormatVisitorWrapperMock, SimpleType.constructUnsafe(javax.money.MonetaryAmount.class));
-        }catch (UnsupportedClassVersionError e){
-            assertTrue("This library only supports Java8", true);
-        }
+        final JsonFormatVisitorWrapper jsonFormatVisitorWrapperMock = mock(JsonFormatVisitorWrapper.class);
+        monetaryAmountSerializer.acceptJsonFormatVisitor(jsonFormatVisitorWrapperMock, SimpleType.constructUnsafe(javax.money.MonetaryAmount.class));
     }
 
 }

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
@@ -25,7 +25,6 @@ import java.util.Locale;
 import static javax.money.Monetary.getDefaultRounding;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
@@ -274,7 +273,7 @@ public final class MonetaryAmountSerializerTest {
     }
 
     @Test
-    public void shouldHandleNullValueFromExpectObjectFormatInSchemaVisitor() throws JsonProcessingException {
+    public void shouldHandleNullValueFromExpectObjectFormatInSchemaVisitor() throws Exception {
         final MonetaryAmountSerializer monetaryAmountSerializer = new MonetaryAmountSerializer(FieldNames.defaults(), new AmountWriter<BigDecimal>() {
             @Override
             public Class<BigDecimal> getType() {
@@ -288,12 +287,7 @@ public final class MonetaryAmountSerializerTest {
         }, new NoopMonetaryAmountFormatFactory());
 
         final JsonFormatVisitorWrapper jsonFormatVisitorWrapperMock = mock(JsonFormatVisitorWrapper.class);
-
-        try {
-            monetaryAmountSerializer.acceptJsonFormatVisitor(jsonFormatVisitorWrapperMock, SimpleType.constructUnsafe(javax.money.MonetaryAmount.class));
-        } catch (NullPointerException ex) {
-            fail();
-        }
+        monetaryAmountSerializer.acceptJsonFormatVisitor(jsonFormatVisitorWrapperMock, SimpleType.constructUnsafe(javax.money.MonetaryAmount.class));
     }
 
 }

--- a/src/test/java/org/zalando/jackson/datatype/money/SchemaTestClass.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/SchemaTestClass.java
@@ -1,0 +1,15 @@
+package org.zalando.jackson.datatype.money;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.money.MonetaryAmount;
+
+@AllArgsConstructor
+@Getter
+public class SchemaTestClass {
+
+    private final MonetaryAmount moneyOne;
+    private final MonetaryAmount moneyTwo;
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
The jsonschemagenarator from mbknor-jackson-jsonschema calls the acceptJsonFormatVisitor everytime he founds an MonetaryAmount-class in the target-class and expects that the JsonFormatVisitorWrapper.ExpectObjectFormat-method returns null if one class is already specified.

Example:
com.fasterxml.jackson.databind.ser.std.BeanSerializerBase#acceptJsonFormatVisitor


## Motivation and Context
To work with other json-schema-versions (>=DraftV4) other generators then Jackson must be supported.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
