### PR TITLE
Ensure that currency is always serialized with the proper serializer

### DIFF
--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
@@ -73,7 +73,7 @@ final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
         json.writeStartObject();
         {
             json.writeObjectField(names.getAmount(), writer.write(value));
-            json.writeObjectField(names.getCurrency(), currency);
+            provider.defaultSerializeField(names.getCurrency(), currency, json);
 
             if (formatted != null) {
                 json.writeStringField(names.getFormatted(), formatted);


### PR DESCRIPTION
It seems like Jackson looses the serialization configuration
when a new `ObjectWriter` gets configured based on an `ObjectMapper`.
This PR ensures that that doesn't happen by using `defaultSerializeField`
of the supplied `SerializerProvider` (which in all cases contains the proper
serialization configuration).

Relates to: https://github.com/quarkusio/quarkus/issues/16081
