### PR TITLE
Fixed Serialization of amount-field when using WRAP_ROOT_VALUE

### DIFF
--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
@@ -72,7 +72,7 @@ final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
 
         json.writeStartObject();
         {
-            json.writeObjectField(names.getAmount(), writer.write(value));
+            provider.defaultSerializeField(names.getAmount(), writer.write(value), json);
             provider.defaultSerializeField(names.getCurrency(), currency, json);
 
             if (formatted != null) {

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
@@ -313,6 +314,26 @@ final class MonetaryAmountSerializerTest {
 
         final JsonFormatVisitorWrapper wrapper = mock(JsonFormatVisitorWrapper.class);
         unit.acceptJsonFormatVisitor(wrapper, SimpleType.constructUnsafe(MonetaryAmount.class));
+    }
+
+    /**
+     * Fixes a bug that caused the amount field to be written as
+     * <code>
+     *  "amount": {"BigDecimal":12.34}
+     * </code>
+     * @param amount
+     * @throws JsonProcessingException
+     */
+    @ParameterizedTest
+    @MethodSource("amounts")
+    void shouldSerializeWithWrapRootValue(final MonetaryAmount amount) throws JsonProcessingException {
+        final ObjectMapper unit = unit(module())
+                .configure(SerializationFeature.WRAP_ROOT_VALUE, true);
+
+        final String expected = "{\"Price\":{\"amount\":{\"amount\":29.95,\"currency\":\"EUR\"}}}";
+        final String actual = unit.writeValueAsString(new Price(amount));
+
+        assertThat(actual).isEqualTo(expected);
     }
 
 }


### PR DESCRIPTION

## Description

Change prevents the amount-field from being wrapped in an extra object "BigDecimel" when SerializationFeature.WRAP_ROOT_VALUE is true. 


## Motivation and Context

In my company we are using DeserializationFeature.UNWRAP_ROOT_VALUE on our RestControllers. When writing clients
using Feign, we want to enable SerializationFeature.WRAP_ROOT_VALUE to avoid having to create Wrapper-Objects for 
each Request-DTO. 
When we did, we found out that the this module performs an additional wrapping of Money-Objects. 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
