### PR TITLE
Implement unwrapping MonetaryAmountSerializer

### DIFF
--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
@@ -23,20 +23,22 @@ final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
     private final FieldNames names;
     private final AmountWriter<?> writer;
     private final MonetaryAmountFormatFactory factory;
-    private final NameTransformer unwrappingNameTransformer;
+    private final boolean isUnwrapping;
+    private final NameTransformer nameTransformer;
 
     MonetaryAmountSerializer(final FieldNames names, final AmountWriter<?> writer,
-            final MonetaryAmountFormatFactory factory, @Nullable final NameTransformer unwrappingNameTransformer) {
+            final MonetaryAmountFormatFactory factory, boolean isUnwrapping, @Nullable final NameTransformer nameTransformer) {
         super(MonetaryAmount.class);
         this.writer = writer;
         this.factory = factory;
         this.names = names;
-        this.unwrappingNameTransformer = unwrappingNameTransformer;
+        this.isUnwrapping = isUnwrapping;
+        this.nameTransformer = nameTransformer;
     }
 
     MonetaryAmountSerializer(final FieldNames names, final AmountWriter<?> writer,
             final MonetaryAmountFormatFactory factory) {
-        this(names, writer, factory, null);
+        this(names, writer, factory, false, null);
     }
 
     @Override
@@ -79,7 +81,7 @@ final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
         final CurrencyUnit currency = value.getCurrency();
         @Nullable final String formatted = format(value, provider);
 
-        if (unwrappingNameTransformer == null) {
+        if (!isUnwrapping) {
             json.writeStartObject();
         }
 
@@ -92,13 +94,13 @@ final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
             }
         }
 
-        if (unwrappingNameTransformer == null) {
+        if (!isUnwrapping) {
             json.writeEndObject();
         }
     }
 
     private String transformName(String name) {
-        return (unwrappingNameTransformer != null) ? unwrappingNameTransformer.transform(name) : name;
+        return (nameTransformer != null) ? nameTransformer.transform(name) : name;
     }
 
     @Nullable
@@ -110,12 +112,11 @@ final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
 
     @Override
     public boolean isUnwrappingSerializer() {
-        return unwrappingNameTransformer != null;
+        return isUnwrapping;
     }
 
     @Override
     public JsonSerializer<MonetaryAmount> unwrappingSerializer(@Nullable final NameTransformer nameTransformer) {
-        NameTransformer unwrappingNameTransformer = nameTransformer != null ? nameTransformer : NameTransformer.NOP;
-        return new MonetaryAmountSerializer(names, writer, factory, unwrappingNameTransformer);
+        return new MonetaryAmountSerializer(names, writer, factory, true, nameTransformer);
     }
 }

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializer.java
@@ -3,11 +3,13 @@ package org.zalando.jackson.datatype.money;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.util.NameTransformer;
 
 import javax.annotation.Nullable;
 import javax.money.CurrencyUnit;
@@ -21,13 +23,20 @@ final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
     private final FieldNames names;
     private final AmountWriter<?> writer;
     private final MonetaryAmountFormatFactory factory;
+    private final NameTransformer unwrappingNameTransformer;
 
     MonetaryAmountSerializer(final FieldNames names, final AmountWriter<?> writer,
-            final MonetaryAmountFormatFactory factory) {
+            final MonetaryAmountFormatFactory factory, @Nullable final NameTransformer unwrappingNameTransformer) {
         super(MonetaryAmount.class);
         this.writer = writer;
         this.factory = factory;
         this.names = names;
+        this.unwrappingNameTransformer = unwrappingNameTransformer;
+    }
+
+    MonetaryAmountSerializer(final FieldNames names, final AmountWriter<?> writer,
+            final MonetaryAmountFormatFactory factory) {
+        this(names, writer, factory, null);
     }
 
     @Override
@@ -70,16 +79,26 @@ final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
         final CurrencyUnit currency = value.getCurrency();
         @Nullable final String formatted = format(value, provider);
 
-        json.writeStartObject();
+        if (unwrappingNameTransformer == null) {
+            json.writeStartObject();
+        }
+
         {
-            provider.defaultSerializeField(names.getAmount(), writer.write(value), json);
-            provider.defaultSerializeField(names.getCurrency(), currency, json);
+            provider.defaultSerializeField(transformName(names.getAmount()), writer.write(value), json);
+            provider.defaultSerializeField(transformName(names.getCurrency()), currency, json);
 
             if (formatted != null) {
-                json.writeStringField(names.getFormatted(), formatted);
+                provider.defaultSerializeField(transformName(names.getFormatted()), formatted, json);
             }
         }
-        json.writeEndObject();
+
+        if (unwrappingNameTransformer == null) {
+            json.writeEndObject();
+        }
+    }
+
+    private String transformName(String name) {
+        return (unwrappingNameTransformer != null) ? unwrappingNameTransformer.transform(name) : name;
     }
 
     @Nullable
@@ -89,4 +108,14 @@ final class MonetaryAmountSerializer extends StdSerializer<MonetaryAmount> {
         return format == null ? null : format.format(value);
     }
 
+    @Override
+    public boolean isUnwrappingSerializer() {
+        return unwrappingNameTransformer != null;
+    }
+
+    @Override
+    public JsonSerializer<MonetaryAmount> unwrappingSerializer(@Nullable final NameTransformer nameTransformer) {
+        NameTransformer unwrappingNameTransformer = nameTransformer != null ? nameTransformer : NameTransformer.NOP;
+        return new MonetaryAmountSerializer(names, writer, factory, unwrappingNameTransformer);
+    }
 }

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
@@ -325,6 +325,23 @@ final class MonetaryAmountSerializerTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Value
+    private static class PriceUnwrappedTransformedNames {
+        @JsonUnwrapped(prefix = "Price-", suffix = "-Field")
+        MonetaryAmount amount;
+    }
+
+    @ParameterizedTest
+    @MethodSource("amounts")
+    void shouldSerializeWithTypeUnwrappedAndNamesTransformed(final MonetaryAmount amount) throws JsonProcessingException {
+        final ObjectMapper unit = unit(module()).activateDefaultTyping(BasicPolymorphicTypeValidator.builder().build());
+
+        final String expected = "{\"Price-amount-Field\":29.95,\"Price-currency-Field\":\"EUR\"}";
+        final String actual = unit.writeValueAsString(new PriceUnwrappedTransformedNames(amount));
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
     @Test
     void shouldHandleNullValueFromExpectObjectFormatInSchemaVisitor() throws Exception {
         final MonetaryAmountSerializer unit = new MonetaryAmountSerializer(FieldNames.defaults(),

--- a/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
+++ b/src/test/java/org/zalando/jackson/datatype/money/MonetaryAmountSerializerTest.java
@@ -1,5 +1,6 @@
 package org.zalando.jackson.datatype.money;
 
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
@@ -303,6 +304,23 @@ final class MonetaryAmountSerializerTest {
 
         final String expected = "{\"amount\":{\"amount\":29.95,\"currency\":\"EUR\"}}";
         final String actual = unit.writeValueAsString(new Price(amount));
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Value
+    private static class PriceUnwrapped {
+        @JsonUnwrapped
+        MonetaryAmount amount;
+    }
+
+    @ParameterizedTest
+    @MethodSource("amounts")
+    void shouldSerializeWithTypeUnwrapped(final MonetaryAmount amount) throws JsonProcessingException {
+        final ObjectMapper unit = unit(module()).activateDefaultTyping(BasicPolymorphicTypeValidator.builder().build());
+
+        final String expected = "{\"amount\":29.95,\"currency\":\"EUR\"}";
+        final String actual = unit.writeValueAsString(new PriceUnwrapped(amount));
 
         assertThat(actual).isEqualTo(expected);
     }


### PR DESCRIPTION
In this commit, MonetaryAmountSerializer.unwrappingSerializer returns a version of itself that doesn't write JSON start and end objects and optionally transforms field names with the given NameTransformer.

This fixes #314 and implements #340.

- [ ] My change requires a change to the documentation.
I don't believe it does, this is a standard feature of Jackson (the annotation is [documented here](https://github.com/FasterXML/jackson-annotations/wiki/Jackson-Annotations)), that works the same for all serializers, so it doesn't need to be mentioned for each serializer. A note could be added to the the readme saying, "works with \@JsonUnwrapped".
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
