### PR TITLE
Fix MonetaryAmountDeserializer visibility

### DIFF
--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountDeserializer.java
@@ -18,12 +18,12 @@ import java.util.Arrays;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static java.lang.String.format;
 
-final class MonetaryAmountDeserializer<M extends MonetaryAmount> extends JsonDeserializer<M> {
+public final class MonetaryAmountDeserializer<M extends MonetaryAmount> extends JsonDeserializer<M> {
 
     private final MonetaryAmountFactory<M> factory;
     private final FieldNames names;
 
-    MonetaryAmountDeserializer(final MonetaryAmountFactory<M> factory, final FieldNames names) {
+    public MonetaryAmountDeserializer(final MonetaryAmountFactory<M> factory, final FieldNames names) {
         this.factory = factory;
         this.names = names;
     }


### PR DESCRIPTION
## Description
After this change we will be able to use MonetaryAmountDeserializer in Spring Boot HTTP request classes.

## Motivation and Context
- Fixes #454

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
