### PR TITLE
Add Deprecation Notice

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,65 @@
+## Migrating from zalando/jackson-datatype-money to FasterXML/jackson-datatypes-misc
+
+This document provides guidance on how to migrate from the `zalando/jackson-datatype-money` module to the new
+`FasterXML/jackson-datatypes-misc` module.
+
+# Changes in Dependency
+
+Replace the dependency in your `pom.xml` or build configuration from:
+
+```xml
+
+<dependency>
+    <groupId>org.zalando</groupId>
+    <artifactId>jackson-datatype-money</artifactId>
+    <version>1.3.0</version>
+</dependency>
+```
+
+to:
+
+```xml
+
+<dependency>
+    <groupId>com.fasterxml.jackson.datatype</groupId>
+    <artifactId>jackson-datatype-moneta</artifactId>
+    <version>2.19.0</version>
+</dependency>
+```
+
+# Changes in ObjectMapper Configuration
+
+Replace the registration of the `MoneyModule` with the `MonetaMoneyModule`:
+
+```java
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.moneta.MonetaMoneyModule;
+
+ObjectMapper mapper = JsonMapper.builder()
+        .addModule(new MonetaMoneyModule())
+        .build();
+```
+
+All the customization options available in the `MonetaMoneyModule` are similar to those in the `MoneyModule`, so you can
+continue to use them as before.
+
+| MoneyModule Method                             | MonetaMoneyModule Method                       |
+|------------------------------------------------|------------------------------------------------|
+| `withDecimalNumbers()`                         | `withDecimalNumbers()`                         |
+| `withQuotedDecimalNumbers()`                   | `withQuotedDecimalNumbers()`                   |
+| `withNumbers(AmountWriter<?> writer)`          | `withNumbers(AmountWriter<?> writer)`          |
+| `withFastMoney()`                              | `withFastMoney()`                              |
+| `withMoney()`                                  | `withMoney()`                                  |
+| `withRoundedMoney()`                           | `withRoundedMoney()`                           |
+| `withRoundedMoney(MonetaryOperator rounding)`  | `withRoundedMoney(MonetaryOperator rounding)`  |
+| `withMonetaryAmount(MonetaryAmountFactory<?>)` | `withMonetaryAmount(MonetaryAmountFactory<?>)` |
+| `withoutFormatting()`                          | `withoutFormatting()`                          |
+| `withDefaultFormatting()`                      | `withDefaultFormatting()`                      |
+| `withFormatting(MonetaryAmountFormatFactory)`  | `withFormatting(MonetaryAmountFormatFactory)`  |
+| `withAmountFieldName(String name)`             | `withAmountFieldName(String name)`             |
+| `withCurrencyFieldName(String name)`           | `withCurrencyFieldName(String name)`           |
+| `withFormattedFieldName(String name)`          | `withFormattedFieldName(String name)`          |
+| `withFieldNames(FieldNames names)`             | `withFieldNames(FieldNames names)`             |
+
+*Table: Method compatibility between MoneyModule and MonetaMoneyModule.*

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,6 @@ This document provides guidance on how to migrate from the `zalando/jackson-data
 Replace the dependency in your `pom.xml` or build configuration from:
 
 ```xml
-
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>jackson-datatype-money</artifactId>
@@ -19,13 +18,14 @@ Replace the dependency in your `pom.xml` or build configuration from:
 to:
 
 ```xml
-
 <dependency>
     <groupId>com.fasterxml.jackson.datatype</groupId>
     <artifactId>jackson-datatype-moneta</artifactId>
-    <version>2.19.0</version>
+    <version>{{pick-recent}}</version>
 </dependency>
 ```
+
+(This migration guide was validated for the 2.19.0 version of `jackson-datatype-moneta` module)
 
 # Changes in ObjectMapper Configuration
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This project is deprecated and no longer maintained.
 Please use the Jackson Datatype modules for [javax-money](https://github.com/FasterXML/jackson-datatypes-misc/tree/2.x/javax-money) and [moneta](https://github.com/FasterXML/jackson-datatypes-misc/tree/2.x/moneta).
 
 Specifically [MonetaMoneyModule](https://github.com/FasterXML/jackson-datatypes-misc/blob/2.x/moneta/src/main/java/com/fasterxml/jackson/datatype/moneta/MonetaMoneyModule.java) is a drop-in replacement for this module. It supports all the same features and is actively maintained.
+For more fine grain control, you can use the [javax-money](https://github.com/FasterXML/jackson-datatypes-misc/tree/2.x/javax-money) Module, and it's helper classes.
+
+See the [migration guide](MIGRATION.md) for more details on how to migrate from this module to the new one.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Jackson Datatype Money
+# Jackson Datatype Money [DEPRECATED]
 
-[![Stability: Sustained](https://masterminds.github.io/stability/sustained.svg)](https://masterminds.github.io/stability/sustained.html)
+[![Stability: Unsupported](https://masterminds.github.io/stability/unsupported.svg)](https://masterminds.github.io/stability/sustained.html)
 ![Build Status](https://github.com/zalando/jackson-datatype-money/workflows/build/badge.svg)
 [![Coverage Status](https://img.shields.io/coveralls/zalando/jackson-datatype-money/main.svg)](https://coveralls.io/r/zalando/jackson-datatype-money)
 [![Code Quality](https://img.shields.io/codacy/grade/7fdac4ae509b403eb837b246e288856f/main.svg)](https://www.codacy.com/app/whiskeysierra/jackson-datatype-money)
@@ -24,6 +24,14 @@ This library reflects our API preferences for [representing monetary amounts in 
 }
 ```
 
+## Deprecation Notice
+This project is deprecated and no longer maintained.
+Please use the Jackson Datatype modules for [javax-money](https://github.com/FasterXML/jackson-datatypes-misc/tree/2.x/javax-money) and [moneta](https://github.com/FasterXML/jackson-datatypes-misc/tree/2.x/moneta).
+
+Specifically [MonetaMoneyModule](https://github.com/FasterXML/jackson-datatypes-misc/blob/2.x/moneta/src/main/java/com/fasterxml/jackson/datatype/moneta/MonetaMoneyModule.java) is a drop-in replacement for this module. It supports all the same features and is actively maintained.
+
+
+
 ## Features
 - enables you to express monetary amounts in JSON
 - can be used in a REST APIs
@@ -44,9 +52,9 @@ Add the following dependency to your project:
 
 ```xml
 <dependency>
-    <groupId>org.zalando</groupId>
-    <artifactId>jackson-datatype-money</artifactId>
-    <version>${jackson-datatype-money.version}</version>
+ <groupId>org.zalando</groupId>
+ <artifactId>jackson-datatype-money</artifactId>
+ <version>${jackson-datatype-money.version}</version>
 </dependency>
 ```
 For ultimate flexibility, this module is compatible with the official version as well as the backport of JavaMoney. The actual version will be selected by a profile based on the current JDK version.
@@ -57,14 +65,14 @@ Register the module with your `ObjectMapper`:
 
 ```java
 ObjectMapper mapper = new ObjectMapper()
-    .registerModule(new MoneyModule());
+        .registerModule(new MoneyModule());
 ```
 
 Alternatively, you can use the SPI capabilities:
 
 ```java
 ObjectMapper mapper = new ObjectMapper()
-    .findAndRegisterModules();
+        .findAndRegisterModules();
 ```
 
 ### Serialization
@@ -75,8 +83,8 @@ and will, by default, serialize it as:
 
 ```json
 {
-  "amount": 99.95,
-  "currency": "EUR"
+ "amount": 99.95,
+ "currency": "EUR"
 }
 ```
 
@@ -84,13 +92,13 @@ To serialize number as a JSON string, you have to configure the quoted decimal n
 
 ```java
 ObjectMapper mapper = new ObjectMapper()
-    .registerModule(new MoneyModule().withQuotedDecimalNumbers());
+        .registerModule(new MoneyModule().withQuotedDecimalNumbers());
 ```
 
 ```json
 {
-  "amount": "99.95",
-  "currency": "EUR"
+ "amount": "99.95",
+ "currency": "EUR"
 }
 ```
 
@@ -101,15 +109,15 @@ have to either enable default formatting:
 
 ```java
 ObjectMapper mapper = new ObjectMapper()
-    .registerModule(new MoneyModule().withDefaultFormatting());
+        .registerModule(new MoneyModule().withDefaultFormatting());
 ```
 
 ... or pass in a `MonetaryAmountFormatFactory` implementation to the `MoneyModule`:
 
 ```java
 ObjectMapper mapper = new ObjectMapper()
-    .registerModule(new MoneyModule()
-        .withFormatting(new CustomMonetaryAmountFormatFactory()));
+        .registerModule(new MoneyModule()
+                .withFormatting(new CustomMonetaryAmountFormatFactory()));
 ```
 
 The default formatting delegates directly to `MonetaryFormats.getAmountFormat(Locale, String...)`.
@@ -127,9 +135,9 @@ writer.writeValueAsString(Money.of(29.95, "EUR"));
 
 ```json
 {
-  "amount": 29.95,
-  "currency": "EUR",
-  "formatted": "29,95 EUR"
+ "amount": 29.95,
+ "currency": "EUR",
+ "formatted": "29,95 EUR"
 }
 ```
 
@@ -142,9 +150,9 @@ writer.writeValueAsString(Money.of(29.95, "USD"));
 
 ```json
 {
-  "amount": 29.95,
-  "currency": "USD",
-  "formatted": "USD29.95"
+ "amount": 29.95,
+ "currency": "USD",
+ "formatted": "USD29.95"
 }
 ```
 
@@ -158,16 +166,16 @@ to the `MoneyModule`:
 
 ```java
 ObjectMapper mapper = new ObjectMapper()
-    .registerModule(new MoneyModule()
-        .withMonetaryAmount(new CustomMonetaryAmountFactory()));
+        .registerModule(new MoneyModule()
+                .withMonetaryAmount(new CustomMonetaryAmountFactory()));
 ```
 
 You can also pass in a method reference:
 
 ```java
 ObjectMapper mapper = new ObjectMapper()
-    .registerModule(new MoneyModule()
-        .withMonetaryAmount(FastMoney::of));
+        .registerModule(new MoneyModule()
+                .withMonetaryAmount(FastMoney::of));
 ```
 
 *Jackson Datatype Money* comes with support for all `MonetaryAmount` implementations from Moneta, the reference
@@ -184,14 +192,14 @@ Module supports deserialization of amount number from JSON number as well as fro
 ### Custom Field Names
 
 As you have seen in the previous examples the `MoneyModule` uses the field names `amount`, `currency` and `formatted`
- by default. Those names can be overridden if desired:
+by default. Those names can be overridden if desired:
 
 ```java
 ObjectMapper mapper = new ObjectMapper()
-    .registerModule(new MoneyModule()
-        .withAmountFieldName("value")
-        .withCurrencyFieldName("unit")
-        .withFormattedFieldName("pretty"));
+        .registerModule(new MoneyModule()
+                .withAmountFieldName("value")
+                .withCurrencyFieldName("unit")
+                .withFormattedFieldName("pretty"));
 ```
 
 ## Usage
@@ -202,8 +210,8 @@ After registering and configuring the module you're now free to directly use `Mo
 import javax.money.MonetaryAmount;
 
 public class Product {
-    private String sku;
-    private MonetaryAmount price;
+ private String sku;
+ private MonetaryAmount price;
     ...
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -147,12 +147,6 @@
             <version>2.0.1.Final</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-moneta</artifactId>
-            <version>2.19.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -187,7 +181,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <failBuildOnAnyVulnerability>false</failBuildOnAnyVulnerability>
+                    <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                     <suppressionFiles>
                         <suppressionFile>cve-suppressions.xml</suppressionFile>
                     </suppressionFiles>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,12 @@
             <version>2.0.1.Final</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-moneta</artifactId>
+            <version>2.19.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -181,7 +187,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+                    <failBuildOnAnyVulnerability>false</failBuildOnAnyVulnerability>
                     <suppressionFiles>
                         <suppressionFile>cve-suppressions.xml</suppressionFile>
                     </suppressionFiles>
@@ -222,7 +228,7 @@
                 <version>3.11.0</version>
                 <configuration>
                     <compilerArgs>
-                        <compilerArg>-Xlint:unchecked,deprecation</compilerArg>
+                        <compilerArg>-Xlint:unchecked</compilerArg>
                         <compilerArg>-Werror</compilerArg>
                     </compilerArgs>
                 </configuration>

--- a/src/main/java/org/zalando/jackson/datatype/money/AmountWriter.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/AmountWriter.java
@@ -4,9 +4,15 @@ import org.apiguardian.api.API;
 
 import javax.money.MonetaryAmount;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
-@API(status = EXPERIMENTAL)
+/**
+ * @deprecated This module is deprecated. Please use
+ * <a href="https://github.com/FasterXML/jackson-datatypes-misc/blob/2.x/javax-money/src/main/java/com/fasterxml/jackson/datatype/javax/money/AmountWriter.java">AmountWriter</a> instead.
+ */
+@Deprecated
+@API(status = DEPRECATED)
 public interface AmountWriter<T> {
 
     Class<T> getType();

--- a/src/main/java/org/zalando/jackson/datatype/money/AmountWriter.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/AmountWriter.java
@@ -5,7 +5,6 @@ import org.apiguardian.api.API;
 import javax.money.MonetaryAmount;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 /**
  * @deprecated This module is deprecated. Please use

--- a/src/main/java/org/zalando/jackson/datatype/money/BigDecimalAmountWriter.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/BigDecimalAmountWriter.java
@@ -5,7 +5,6 @@ import org.apiguardian.api.API;
 import java.math.BigDecimal;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 /**
  * @deprecated This module is deprecated. Please use

--- a/src/main/java/org/zalando/jackson/datatype/money/BigDecimalAmountWriter.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/BigDecimalAmountWriter.java
@@ -4,9 +4,15 @@ import org.apiguardian.api.API;
 
 import java.math.BigDecimal;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
-@API(status = EXPERIMENTAL)
+/**
+ * @deprecated This module is deprecated. Please use
+ * <a href="https://github.com/FasterXML/jackson-datatypes-misc/blob/2.x/javax-money/src/main/java/com/fasterxml/jackson/datatype/javax/money/BigDecimalAmountWriter.java">BigDecimalAmountWriter</a> instead.
+ */
+@Deprecated
+@API(status = DEPRECATED)
 public interface BigDecimalAmountWriter extends AmountWriter<BigDecimal> {
 
     @Override

--- a/src/main/java/org/zalando/jackson/datatype/money/CurrencyUnitDeserializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/CurrencyUnitDeserializer.java
@@ -10,9 +10,15 @@ import javax.money.CurrencyUnit;
 import javax.money.Monetary;
 import java.io.IOException;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
-@API(status = MAINTAINED)
+/**
+ * @deprecated This module is deprecated. Please use
+ * <a href="https://github.com/FasterXML/jackson-datatypes-misc/blob/2.x/javax-money/src/main/java/com/fasterxml/jackson/datatype/javax/money/CurrencyUnitDeserializer.java">CurrencyUnitDeserializer</a> instead.
+ */
+@Deprecated
+@API(status = DEPRECATED)
 public final class CurrencyUnitDeserializer extends JsonDeserializer<CurrencyUnit> {
 
     @Override

--- a/src/main/java/org/zalando/jackson/datatype/money/CurrencyUnitDeserializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/CurrencyUnitDeserializer.java
@@ -11,7 +11,6 @@ import javax.money.Monetary;
 import java.io.IOException;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.MAINTAINED;
 
 /**
  * @deprecated This module is deprecated. Please use

--- a/src/main/java/org/zalando/jackson/datatype/money/CurrencyUnitSerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/CurrencyUnitSerializer.java
@@ -12,7 +12,6 @@ import javax.money.CurrencyUnit;
 import java.io.IOException;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.MAINTAINED;
 
 /**
  * @deprecated This module is deprecated. Please use

--- a/src/main/java/org/zalando/jackson/datatype/money/CurrencyUnitSerializer.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/CurrencyUnitSerializer.java
@@ -11,9 +11,15 @@ import org.apiguardian.api.API;
 import javax.money.CurrencyUnit;
 import java.io.IOException;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
-@API(status = MAINTAINED)
+/**
+ * @deprecated This module is deprecated. Please use
+ * <a href="https://github.com/FasterXML/jackson-datatypes-misc/blob/2.x/javax-money/src/main/java/com/fasterxml/jackson/datatype/javax/money/CurrencyUnitSerializer.java">CurrencyUnitSerializer</a> instead.
+ */
+@Deprecated
+@API(status = DEPRECATED)
 public final class CurrencyUnitSerializer extends StdSerializer<CurrencyUnit> {
 
     CurrencyUnitSerializer() {

--- a/src/main/java/org/zalando/jackson/datatype/money/DeprecationNotice.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/DeprecationNotice.java
@@ -1,0 +1,14 @@
+package org.zalando.jackson.datatype.money;
+
+/**
+ * This class exists purely to trigger compiler warnings when the library is used.
+ * @deprecated This library is deprecated. Please migrate to
+ * <a href="https://github.com/FasterXML/jackson-datatypes-misc/tree/2.x/moneta">MonetaMoneyModule</a> instead.
+ */
+@Deprecated
+public class DeprecationNotice {
+    static {
+        System.err.println("WARNING: jackson-datatype-money is deprecated. " +
+                "Please migrate to MonetaMoneyModule from jackson-datatypes-misc.");
+    }
+}

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFactory.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFactory.java
@@ -7,9 +7,15 @@ import javax.money.MonetaryAmount;
 
 import java.math.BigDecimal;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.STABLE;
 
-@API(status = STABLE)
+/**
+ * @deprecated This module is deprecated. Please use
+ * <a href="https://github.com/FasterXML/jackson-datatypes-misc/blob/2.x/javax-money/src/main/java/com/fasterxml/jackson/datatype/javax/money/MonetaryAmountFactory.java">MonetaryAmountFactory</a> instead.
+ */
+@Deprecated
+@API(status = DEPRECATED)
 @FunctionalInterface
 public interface MonetaryAmountFactory<M extends MonetaryAmount> {
 

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFactory.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFactory.java
@@ -4,11 +4,9 @@ import org.apiguardian.api.API;
 
 import javax.money.CurrencyUnit;
 import javax.money.MonetaryAmount;
-
 import java.math.BigDecimal;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.STABLE;
 
 /**
  * @deprecated This module is deprecated. Please use

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFormatFactory.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFormatFactory.java
@@ -6,9 +6,15 @@ import javax.annotation.Nullable;
 import javax.money.format.MonetaryAmountFormat;
 import java.util.Locale;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.STABLE;
 
-@API(status = STABLE)
+/**
+ * @deprecated This module is deprecated. Please use
+ * <a href="https://github.com/FasterXML/jackson-datatypes-misc/blob/2.x/javax-money/src/main/java/com/fasterxml/jackson/datatype/javax/money/MonetaryAmountFormatFactory.java">MonetaryAmountFormatFactory</a> instead.
+ */
+@Deprecated
+@API(status = DEPRECATED)
 @FunctionalInterface
 public interface MonetaryAmountFormatFactory {
 

--- a/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFormatFactory.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MonetaryAmountFormatFactory.java
@@ -7,7 +7,6 @@ import javax.money.format.MonetaryAmountFormat;
 import java.util.Locale;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.STABLE;
 
 /**
  * @deprecated This module is deprecated. Please use

--- a/src/main/java/org/zalando/jackson/datatype/money/MoneyModule.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MoneyModule.java
@@ -17,8 +17,6 @@ import javax.money.MonetaryRounding;
 import javax.money.format.MonetaryFormats;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
-import static org.apiguardian.api.API.Status.STABLE;
 
 /**
  * @deprecated This module is deprecated. Please use

--- a/src/main/java/org/zalando/jackson/datatype/money/MoneyModule.java
+++ b/src/main/java/org/zalando/jackson/datatype/money/MoneyModule.java
@@ -16,10 +16,15 @@ import javax.money.MonetaryOperator;
 import javax.money.MonetaryRounding;
 import javax.money.format.MonetaryFormats;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
-@API(status = STABLE)
+/**
+ * @deprecated This module is deprecated. Please use
+ * <a href="https://github.com/FasterXML/jackson-datatypes-misc/tree/2.x/moneta">MonetaMoneyModule</a> instead.
+ */
+@API(status = DEPRECATED)
 public final class MoneyModule extends Module {
 
     private final AmountWriter<?> writer;
@@ -89,7 +94,7 @@ public final class MoneyModule extends Module {
         return withNumbers(new QuotedDecimalAmountWriter());
     }
 
-    @API(status = EXPERIMENTAL)
+    @API(status = DEPRECATED)
     public MoneyModule withNumbers(final AmountWriter<?> writer) {
         return new MoneyModule(writer, names, formatFactory, amountFactory,
                 fastMoneyFactory, moneyFactory, roundedMoneyFactory);


### PR DESCRIPTION
Add Deprecation Notice to this repository 

## Description
Add Deprecation Notice to this repository and point to https://github.com/FasterXML/jackson-datatypes-misc

- There are comments in all deprecated classes pointing to replacement options
- There is a static [code block](https://github.com/zalando/jackson-datatype-money/blob/5fe2a81c56d9f7abe5780b6227a40f64dbe675e0/src/main/java/org/zalando/jackson/datatype/money/DeprecationNotice.java) which logs that the library has been deprecated
- Migration [guide](https://github.com/zalando/jackson-datatype-money/blob/5fe2a81c56d9f7abe5780b6227a40f64dbe675e0/MIGRATION.md) added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
