### PR TITLE
Migrate to Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,17 +298,6 @@
         </plugins>
     </build>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <profiles>
         <profile>
             <id>release</id>
@@ -355,14 +344,14 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <deploymentName>${project.name}:${project.version}</deploymentName>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Description

Migrating from OSSRH to Central Portal for publishing of releases. See https://central.sonatype.org/publish/generate-portal-token/ for authentication. 

## Motivation and Context
See https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/ 

- [x] fix `pom` violations
- [x] fix javadocs violations
- [x] requires #458 